### PR TITLE
UX: fix typo in lazyYT.css

### DIFF
--- a/lazyYT.css
+++ b/lazyYT.css
@@ -13,7 +13,7 @@
     left: 12px!important;
     position: absolute!important;
     margin: 0!important;
-    padding: 1em!important;
+    padding: 0.5em!important;
     line-height: 1!important;
     font-style: normal!important;
     font-weight: normal!important;


### PR DESCRIPTION
For some reason my previous PR https://github.com/tylerpearson/lazyYT/pull/10 had wrong padding (twice as big).
Fixing it now so that it will look as [expected](https://github.com/discourse/discourse/pull/2819#issue-43679040).

My apologies.
